### PR TITLE
deploy script code improvement

### DIFF
--- a/deploy/wallet_principals.txt
+++ b/deploy/wallet_principals.txt
@@ -1,1 +1,11 @@
-# put wallet canister principals here and remove this comment
+q2y4e-giaaa-aaaap-aaoka-cai
+neicu-baaaa-aaaam-aaxqa-cai
+tp77g-mqaaa-aaaal-abi4q-cai
+672sd-gaaaa-aaaan-qa3oa-cai
+a2gic-zqaaa-aaaal-qbgyq-cai
+ebpt7-aiaaa-aaaak-adiaq-cai
+66qs7-syaaa-aaaag-qa2uq-cai
+hbuku-aqaaa-aaaag-aazga-cai
+g7onv-maaaa-aaaap-qatza-cai
+rln4c-rqaaa-aaaao-aatra-cai
+pklns-bqaaa-aaaak-qay3q-cai

--- a/test/performance_tests/cycle_stats.txt
+++ b/test/performance_tests/cycle_stats.txt
@@ -1,9 +1,9 @@
 [LED] Empty batch: 1563
 [LED] Batch with one empty Tx: 2801
 [LED] One simple Tx: 23188
-[LED] 16,384 txs: 210852131
-[LED] Heavy tx: 88788961
-[LED] 5 heavy tx-s (max possible batch): 443855058
+[LED] 16,384 txs: 206517191
+[LED] Heavy tx: 88786105
+[LED] 5 heavy tx-s (max possible batch): 443950202
 [AGG] submit simple Tx: 16149
 [AGG] submit + auto-enqueue simple Tx: 12682
 [AGG] submit heavy tx: 181456410


### PR DESCRIPTION
use `cat <<-EOF` and printf with the goal of using as much literal characters possible, reducing quotes as much as possible

separate out dfx.json creation into own loop

set execution flag for generated scripts