### PR TITLE
Simplified minter_api

### DIFF
--- a/src/minter/minter.did
+++ b/src/minter/minter.did
@@ -38,7 +38,7 @@ type InitResult =
         };
    ok: nat;
  };
-service : (principal) -> {
+service : (opt principal) -> {
     // init
     init: () -> (InitResult); 
     // query

--- a/src/minter/minter.did
+++ b/src/minter/minter.did
@@ -11,7 +11,6 @@ type MintResult =
       MissingApproval;
       NonZeroAssetSum;
       NotAController;
-      NotInitialized;
       OwnersNotUnique;
       SubaccountIdTooLarge;
       TooManyContributions;
@@ -26,19 +25,26 @@ type MintResult =
 type RefundResult =
   variant {
     err: variant {
-      NotInitialized;
       RefundError;
       NothingToRefund;
     };
     ok;
   };
-type AssetIdResult =
-variant {
-    err: variant {NotInitialized;};
-    ok: nat;
-};
+type InitResult =
+ variant {
+   err: variant {
+          FeeError;
+          NoSpace;
+        };
+   ok: nat;
+ };
 service : (principal) -> {
-    assetId: () -> (AssetIdResult) query;
+    // init
+    init: () -> (InitResult); 
+    // query
+    assetId: () -> (opt nat) query;
+    ledgerPrincipal: () -> (principal) query;
+    // update
     mint: (principal, SubaccountId) -> (MintResult);
     refundAll: () -> (RefundResult);
 }

--- a/src/minter/minter_api.mo
+++ b/src/minter/minter_api.mo
@@ -1,87 +1,58 @@
-import Principal "mo:base/Principal";
-import Nat8 "mo:base/Nat8";
-import Nat32 "mo:base/Nat32";
-import Nat64 "mo:base/Nat64";
-import Tx "../shared/transaction";
-import StableMemory "mo:base/ExperimentalStableMemory";
-import Minter "minter";
+import Debug "mo:base/Debug";
 import Error "mo:base/Error";
+import Option "mo:base/Option";
+import Principal "mo:base/Principal";
 import R "mo:base/Result";
+
+import Minter "minter";
+import Tx "../shared/transaction";
 
 actor class MinterAPI(ledger : Principal) = self {
 
-  private var minter_: ?Minter.Minter = null;
+  stable let Ledger = actor (Principal.toText(ledger)) : Minter.LedgerInterface; 
+  stable var saved : ?(Principal, Nat) = null; // (own principal, asset id)
+  var minter = switch (saved) {
+    case (?v) ?Minter.Minter(v.0, Ledger, v.1);
+    case (_) null
+  };
 
-  public shared func init(): async R.Result<(), { #NoSpace; #FeeError }> {
-    switch (minter_) {
-      case (?m) #ok();
-      case (_) {
-        let ledgerActor = actor (Principal.toText(ledger)) : Minter.LedgerInterface;
-        let savedState = readStableState();
-        if (Principal.equal(ledger, savedState.ledgerPrincipal)) {
-          minter_ := ?Minter.Minter(Principal.fromActor(self), ledgerActor, savedState.assetId);
-          #ok();
-        } else {
-          let ftResult = await ledgerActor.createFungibleToken();
-          switch(ftResult) {
-            case(#ok res) {
-              minter_ := ?Minter.Minter(Principal.fromActor(self), ledgerActor, res);
-              writeStableState({ ledgerPrincipal = ledger; assetId = res; });
-              #ok();
-            };
-            case(#err e) #err(e);
-          };
+  var initActive = false;
+  public shared func init(): async R.Result<Nat, { #NoSpace; #FeeError }> {
+    // trap if values are already initialized
+    assert Option.isNull(saved); 
+    // trap if creation of asset id is already under way
+    assert (not initActive);
+    initActive := true;
+    let res = await Ledger.createFungibleToken();
+    switch(res) {
+      case(#ok id) {
+          saved := ?(Principal.fromActor(self), id);
+          minter := ?Minter.Minter(Principal.fromActor(self), Ledger, id)
         };
-      };
+      case(_) {} 
     };
+    initActive := false;
+    res
   };
 
-  public shared query func assetId(): async R.Result<Nat, { #NotInitialized }> {
-    switch(minter_) {
-      case (?m) #ok(m.assetId);
-      case (_) #err(#NotInitialized);
-    };
+  public query func assetId(): async ?Nat {
+    // let id : (Principal, Nat) -> Nat = func (x) { x.1 };
+    let id = func (x : (Principal, Nat)) : Nat { x.1 };
+    Option.map(saved, id);
   };
+  public query func ledgerPrincipal(): async Principal = async ledger;
 
-  public shared({caller}) func mint(p: Principal, n: Tx.SubaccountId): async R.Result<Nat, Minter.MintError or { #NotInitialized }> {
-    switch(minter_) {
+  public shared({caller}) func mint(p: Principal, n: Tx.SubaccountId): async R.Result<Nat, Minter.MintError> {
+    switch(minter) {
       case (?m) await m.mint(caller, p, n);
-      case (_) #err(#NotInitialized);
+      case (_) Debug.trap("not initialized");
     };
   };
 
-  public shared({caller}) func refundAll(): async R.Result<(), Minter.RefundError or { #NotInitialized }> {
-    switch(minter_) {
+  public shared({caller}) func refundAll(): async R.Result<(), Minter.RefundError> {
+    switch(minter) {
       case (?m) await m.refundAll(caller);
-      case (_) #err(#NotInitialized);
+      case (_) Debug.trap("not initialized");
     };
   };
-
-  // stable memory schema:
-  // ┏━━━━━━━━┳━━━━━━┳━━━━━━━┓
-  // ┃ Offset ┃ Size ┃ Type  ┃ Comment
-  // ┣━━━━━━━━╋━━━━━━╋━━━━━━━┫
-  // ┃ 0      ┃ 1    ┃ Nat8  ┃ size of ledger principal blob
-  // ┣━━━━━━━━╋━━━━━━╋━━━━━━━┫
-  // ┃ 1      ┃ <0>  ┃ Blob  ┃ ledger principal blob
-  // ┣━━━━━━━━╋━━━━━━╋━━━━━━━┫
-  // ┃ <0>+1  ┃ 4    ┃ Nat32 ┃ asset Id, we allow it to be maximum 24-bit length, so Nat32 is enough
-  // ┗━━━━━━━━┻━━━━━━┻━━━━━━━┛
-  type StableState = { ledgerPrincipal: Principal; assetId: Tx.AssetId };
-  private func readStableState(): StableState {
-    let ledgerPrincipalBlobSize = Nat8.toNat(StableMemory.loadNat8(0));
-    {
-      ledgerPrincipal = Principal.fromBlob(StableMemory.loadBlob(1, ledgerPrincipalBlobSize));
-      assetId = Nat32.toNat(StableMemory.loadNat32(Nat64.fromNat(1+ledgerPrincipalBlobSize)));
-    };
-  };
-  private func writeStableState(state: StableState): () {
-    let ledgerPrincipalBlob: Blob = Principal.toBlob(state.ledgerPrincipal);
-    let ledgerPrincipalBlobSize: Nat = ledgerPrincipalBlob.size();
-
-    StableMemory.storeNat8(0, Nat8.fromNat(ledgerPrincipalBlob.size()));
-    StableMemory.storeBlob(1, ledgerPrincipalBlob);
-    StableMemory.storeNat32(Nat64.fromNat(1+ledgerPrincipalBlobSize), Nat32.fromNat(state.assetId));
-  };
-
 };


### PR DESCRIPTION
Make use of stable vars
No `postupgrade` system function is needed, nor does `init()` need to be called after an upgrade (only on first install).

Also:
- simplified return values by trapping instead of gracefully returning #NotInitialized
- fixed concurrency bug if init() is called twice before completing